### PR TITLE
HTTP リクエストヘッダを指定できる様にするためにオプションパラメータを受け付ける

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.1.0

--- a/fluent-plugin-bugsnag.gemspec
+++ b/fluent-plugin-bugsnag.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-bugsnag"
-  spec.version       = '0.1.1'
+  spec.version       = '0.2.0'
   spec.authors       = ["koshigoe"]
   spec.email         = ["koshigoeb@gmail.com"]
 

--- a/lib/fluent/plugin/out_bugsnag.rb
+++ b/lib/fluent/plugin/out_bugsnag.rb
@@ -17,13 +17,14 @@ module Fluent
 
     def write(chunk)
       chunk.msgpack_each do |(tag,time,record)|
-        request(record['url'], record['body'])
+        options = record['options'] || {}
+        request(record['url'], record['body'], options)
       end
     end
 
     private
 
-    def request(url, body)
+    def request(url, body, options = {})
       uri = URI.parse(url)
       http = Net::HTTP.new(uri.host, uri.port, @bugsnag_proxy_host, @bugsnag_proxy_port, @bugsnag_proxy_user, @bugsnag_proxy_password)
       http.read_timeout = @bugsnag_timeout
@@ -36,13 +37,22 @@ module Fluent
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 
-      request = Net::HTTP::Post.new(path(uri), {"Content-Type" => "application/json"})
+      headers = options.key?('headers') ? options['headers'] : {}
+      headers.merge!(default_headers)
+
+      request = Net::HTTP::Post.new(path(uri), headers)
       request.body = body
       http.request(request)
     end
 
     def path(uri)
       uri.path == "" ? "/" : uri.path
+    end
+
+    def default_headers
+      {
+        "Content-Type" => "application/json",
+      }
     end
   end
 end

--- a/test/fluent/test_bugsnag.rb
+++ b/test/fluent/test_bugsnag.rb
@@ -28,7 +28,7 @@ class HogeOutputTest < Test::Unit::TestCase
     assert_equal 10, d.instance.bugsnag_timeout
   end
 
-  def test_write
+  def test_write_without_options
     d = create_driver ''
 
     stub_request(:post, "https://www.example.com/")
@@ -37,6 +37,39 @@ class HogeOutputTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     d.emit({'url' => 'https://www.example.com/', 'body' => 'json'}, time)
+    d.run
+  end
+
+  def test_write_with_empty_options
+    d = create_driver ''
+
+    stub_request(:post, "https://www.example.com/")
+      .with(:body => 'json', :headers => {'Content-Type' => 'application/json'})
+      .to_return(:status => 200, :body => "", :headers => {})
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.emit({'url' => 'https://www.example.com/', 'body' => 'json', 'options' => {}}, time)
+    d.run
+  end
+
+  def test_write_with_options_including_headers
+    d = create_driver ''
+
+    stub_request(:post, "https://www.example.com/")
+      .with(:body => 'json', :headers => {'Content-Type' => 'application/json', 'Bugsnag-Payload-Version' => '4.0'})
+      .to_return(:status => 200, :body => "", :headers => {})
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    data = {
+      'url' => 'https://www.example.com/',
+      'body' => 'json',
+      'options' => {
+        'headers' => {
+          'Bugsnag-Payload-Version' => '4.0'
+        }
+      }
+    }
+    d.emit(data, time)
     d.run
   end
 end


### PR DESCRIPTION
`Bugsnag::Delivery::{DeliverClass}#deliver` の第四引数 `options` (Hash)を使って HTTP リクエストヘッダを指定する実装がある。

https://github.com/bugsnag/bugsnag-ruby/blob/44c6ab14d7b82f6ed39109225897e7e49927085c/lib/bugsnag/delivery/synchronous.rb#L43-L44

https://github.com/bugsnag/bugsnag-ruby/blob/44c6ab14d7b82f6ed39109225897e7e49927085c/lib/bugsnag.rb#L117-L119

[bugsnag-delivery-fluent](https://github.com/feedforce/bugsnag-delivery-fluent) でも同様に HTTP リクエストヘッダを options 引数経由で受け渡しできる様にする前提で、このプラグインを拡張する。